### PR TITLE
Specify headers in fetch call.

### DIFF
--- a/token.html
+++ b/token.html
@@ -90,7 +90,11 @@
     <script src="js/clipboard.min.js"></script>
 
     <script type="text/javascript">
-        fetch('/token')
+        fetch('/token', {
+            headers: { 
+                'Content-Type': 'application/json'
+                }
+            })
             .then(response => response.text())
             .then(responseText => {
                 const base64Url = responseText.split('.')[1];


### PR DESCRIPTION
Added explicit content-type declaration in the fetch header.

Fixes a 415 response received during the `GET /token` fetch call.