### PR TITLE
Update lega-commander link to point towards new monorepo

### DIFF
--- a/retrieval.html
+++ b/retrieval.html
@@ -61,7 +61,7 @@
                 </div>
                 <div class="grid-column span-half mb3 reveal-on-scroll is-revealing">
                     <img class="illustration--small mb1" src="/img/uploading.svg" alt="Put in a vault">
-                    <p><a class="link link--text" target="_blank" href="https://github.com/elixir-oslo/lega-commander">File manager</a></p>
+                    <p><a class="link link--text" target="_blank" href="https://github.com/ELIXIR-NO/FEGA-Norway/tree/main/cli/lega-commander">File manager</a></p>
                 </div>
             </div>
         </div>
@@ -139,7 +139,7 @@
                     </div>
                     <p class="italic text--gray mb1">
                         You can find more details on the tool
-                        <a class="link link--text" target="_blank" href="https://github.com/elixir-oslo/lega-commander">page</a>
+                        <a class="link link--text" target="_blank" href="https://github.com/ELIXIR-NO/FEGA-Norway/tree/main/cli/lega-commander">page</a>
                         on GitHub.
                     </p>
                 </div>

--- a/submission.html
+++ b/submission.html
@@ -66,7 +66,7 @@
                 </div>
                 <div class="grid-column span-half mb3 reveal-on-scroll is-revealing">
                     <img class="illustration--small mb1" src="/img/uploading.svg" alt="Put in a vault">
-                    <p><a class="link link--text" target="_blank" href="https://github.com/elixir-oslo/lega-commander">File manager</a></p>
+                    <p><a class="link link--text" target="_blank" href="https://github.com/ELIXIR-NO/FEGA-Norway/tree/main/cli/lega-commander">File manager</a></p>
                 </div>
             </div>
         </div>
@@ -179,7 +179,7 @@
                         </p>
                     </div>
                     <p class="italic text--gray mb1">
-                        You can find more details on the tool <a class="link link--text" target="_blank" href="https://github.com/elixir-oslo/lega-commander">page</a> at the GitHub.
+                        You can find more details on the tool <a class="link link--text" target="_blank" href="https://github.com/ELIXIR-NO/FEGA-Norway/tree/main/cli/lega-commander">page</a> at the GitHub.
                     </p>
                 </div>
                 <div class="grid-column span-1"></div>


### PR DESCRIPTION
The old lega-commander repository is being deprecated. I have updated the links to point the users to the new monorepo.
